### PR TITLE
Add :len() method

### DIFF
--- a/atomic.lua
+++ b/atomic.lua
@@ -173,6 +173,8 @@ local function defineAtomicTensorVector(typename)
         assert(self)
         return self.numElements[1]
     end
+    -- __len requires Lua version >= 5.2
+    mt.len = mt.__len
 
     function mt:__write(f)
         assert(self)

--- a/string.lua
+++ b/string.lua
@@ -132,6 +132,8 @@ function mt:__len()
     assert(self)
     return self.numPointers[1]
 end
+-- __len requires Lua version >= 5.2
+mt.len = mt.__len
 
 function mt:__write(f)
     assert(self)

--- a/tensor.lua
+++ b/tensor.lua
@@ -113,6 +113,8 @@ local function defineTensorVector(typename)
         assert(self)
         return self.size[1]
     end
+    -- __len requires Lua version >= 5.2
+    mt.len = mt.__len
 
     function mt:__write(f)
         assert(self)


### PR DESCRIPTION
Resolving `#` to `__len` is supported starting from Lua 5.2
(http://www.luafaq.org/#T8.2.5). People still using 5.1 will need to call the
`len()` method.